### PR TITLE
fix: yarn add instead of install

### DIFF
--- a/docs/plugin/plugin-react.md
+++ b/docs/plugin/plugin-react.md
@@ -9,7 +9,7 @@ Você pode usar [@openpix/react](https://www.npmjs.com/package/@openpix/react) p
 ## Como instalar
 
 ```jsx
-yarn install @openpix/react
+yarn add @openpix/react
 ```
 
 ## Configurar Polyfills
@@ -18,7 +18,7 @@ Este plugin usa o core-js para polyfill Promises
 Instale core-js
 
 ```jsx
-yarn install core-js
+yarn add core-js
 ```
 
 Adicione seu entrypoint do seu App


### PR DESCRIPTION
You can't use yarn install anymore, change the docs for installing the plugin to follow the required.
![image](https://user-images.githubusercontent.com/52898510/198601124-01e42a6e-e28c-4bd4-accf-f5024155a84a.png)
